### PR TITLE
Increase file limit for edgeware service

### DIFF
--- a/docs/understanding-edgeware/staking/validation/setting-up-a-node/README.md
+++ b/docs/understanding-edgeware/staking/validation/setting-up-a-node/README.md
@@ -152,7 +152,7 @@ Set up the node as a system service. To do this, navigate into the root director
     echo '[Unit]'
     echo 'Description=Edgeware'
     echo '[Service]'
-    echo 'Type=exec'
+    echo 'LimitNOFILE=infinity'
     echo 'WorkingDirectory='`pwd`
     echo 'ExecStart='`pwd`'/target/release/edgeware --chain=edgeware --ws-external --rpc-cors "*"'
     echo '[Install]'


### PR DESCRIPTION
This increases the default ~4000 file limit for the service to "infinity". Also removed Type=Exec as that is not supported in Ubuntu 18.04.