### PR TITLE
Corrected capitalization of "How"

### DIFF
--- a/docs/advanced-topics/running-cross-chain-protocols/cross-chain-protocols.md
+++ b/docs/advanced-topics/running-cross-chain-protocols/cross-chain-protocols.md
@@ -1,5 +1,5 @@
 # Cross Chain Protocols
 
-* how to port a token over \(directly mirroring state\)
+* How to port a token over \(directly mirroring state\)
 * Having wrapped tokens, what to tell an exchange?
 


### PR DESCRIPTION
I don't think this page makes much sense, it is supposed to list cross chain protocols, but the contents don't do that:

"* How to port a token over \(directly mirroring state\)
* Having wrapped tokens, what to tell an exchange?"

I'm not very clear what they mean....