### PR TITLE
Update exchanges.md

### DIFF
--- a/docs/other-resources/exchanges.md
+++ b/docs/other-resources/exchanges.md
@@ -11,4 +11,5 @@ This list is provided without endorsement by Commonwealth Labs, developers of Ed
 | MXC | DG USDT | [https://www.mxc.com/trade/easy\#EDG\_USDT](https://www.mxc.com/trade/easy#EDG_USDT) | May be staking or voting with users tokens. |
 | HotBit | EDG/BTC and EDG/USDT | [https://www.hotbit.io/exchange](https://www.hotbit.io/exchange?symbol=EDG_BTC) |  |
 | Biki | EDG/USDT | [https://www.biki.com/en\_US/trade/EDG\_USDT](https://www.biki.com/en_US/trade/EDG_USDT) | Has been known to disable withdrawal of EDG involuntarily. |
+| Gate.io | EDG/USDT | [https://www.gate.io/en/trade/EDG_USDT](https://www.gate.io/en/trade/EDG_USDT) | Gate.io wallets have been suspended after transfers for weeks. |
 


### PR DESCRIPTION
A warning for Gate.io is missing. The volume on coinmarketcap and the reputation of Gate.io may seem good in general but they are certainly not the best option to trade EDG.